### PR TITLE
fix: one protection class for all three cleanup paths

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -45,6 +45,20 @@ Tests drive the two seams separately via `CC_REAPER_PS_SNAPSHOT_FILE` (`pid tty 
 
 **zsh portability**: this project is installed into zsh, so `claude-guard`'s reaping paths must avoid two zsh traps that bash hides — `status` is a read-only variable (use `proc_status`), and arrays cannot be walked by numeric index (`${!arr[@]}` is `bad substitution`, `${arr[0]}` is empty). Kill candidates are carried as `pid<TAB>detail` records iterated by value. `zsh -n` belongs in the syntax check alongside `bash -n`.
 
+**Protection classes**: `_cc_reaper_protection_class` is the single owner of how protected a process is, returning `immutable`, `shared`, or `none` for a command line. All three cleanup paths consult it, which is what keeps them from disagreeing:
+
+| Path | `immutable` | `shared` | `none` |
+|------|-------------|----------|--------|
+| Pattern-based cleanup | never | exempt, unless a user `cleanup` rule covers it | family predicates decide |
+| Process-group cleanup | never | skipped | signalled on membership |
+| Runaway phase | never selected | selected, and signalled | not selected |
+
+They previously carried three separate lists (`_cc_reaper_protected_pattern`, `_cc_reaper_is_direct_cleanup_protected`, and an `MCP_WHITELIST` local to `_claude_pgid_kill`) that had drifted apart: a runaway shared MCP was selected by one and skipped by another, `mcp-server-stripe` was protected where `@stripe/mcp` was not, and a stuck system scanner was reachable by the runaway phase.
+
+**Runaway phase specifics**: it never selects `immutable`, so cc-reaper does not SIGTERM security software or a Spotlight reindex however hot they get. It *does* signal the `shared` service it selected — that is the point of the phase, and `_claude_pgid_kill` takes a `force_target` argument for exactly that PID, sparing its group siblings. Reported counts are deliveries, not intentions: a candidate spared at the signal stage is not counted, adds nothing to the freed total, and raises no notification.
+
+**Tree RSS** (`_claude_tree_rss`) sums the whole descendant tree in kilobytes and converts once, from a single `ps` walked in awk. Truncating each member first cost ~0.5 MB per process, and stopping at grandchildren missed anything behind a wrapper chain; the single-pass form is also ~5x faster than the two-level version it replaced.
+
 **proc-janitor** is an external Rust daemon (installed via Homebrew or Cargo). The config.toml here only configures its behavior — the daemon code lives at github.com/jhlee0409/proc-janitor.
 
 **Installer idempotency**: `install.sh` checks for existing installations before modifying shell configs, copying hooks, or installing dependencies. It uses `sed` to replace `~` with the actual home path in the proc-janitor config.
@@ -83,6 +97,7 @@ bash tests/stop-hook-env.sh            # Validate CC_STOP_HOOK_DISABLE / CC_STOP
 bash tests/cc-monitor-optimize.sh      # Validate cc-monitor optimization menu logic
 bash tests/cc-monitor-runaway.sh       # Validate runaway protected process detection
 bash tests/guard-session-detect.sh     # Validate session detection + guard phases under bash and zsh
+bash tests/protection-classes.sh       # Validate protection classes, runaway selection/signalling, tree RSS
 bash -n shell/claude-cleanup.sh        # Syntax check
 bash -n shell/cc-monitor.sh            # Syntax check
 bash -n hooks/stop-cleanup-orphans.sh  # Syntax check

--- a/openspec/changes/unify-protection-classes/.openspec.yaml
+++ b/openspec/changes/unify-protection-classes/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-11

--- a/openspec/changes/unify-protection-classes/proposal.md
+++ b/openspec/changes/unify-protection-classes/proposal.md
@@ -1,0 +1,56 @@
+## Why
+
+cc-reaper decides what it may signal from three independently-grown lists:
+
+| Predicate | Used by |
+|---|---|
+| `_cc_reaper_protected_pattern` | pattern-based cleanup, runaway **selection** |
+| `_cc_reaper_is_direct_cleanup_protected` (immutable ∨ user `protect` ∨ protected pattern) | process-group cleanup |
+| `MCP_WHITELIST`, local to `_claude_pgid_kill` | the **signal** stage of group and runaway kills |
+
+They disagree, and the disagreements are not cosmetic. Measured against representative command lines:
+
+| Command | immutable | protected | group whitelist | Consequence |
+|---|---|---|---|---|
+| `Bitdefender`, `mdworker`, `mds_stores` | yes | yes | **no** | runaway selects **and signals** a system scanner |
+| `chrome-devtools-mcp`, `context7-mcp`, `@stripe/mcp`, `sequential-thinking` | no | yes | yes | runaway selects, signal stage skips — reported reaped, still running |
+| `mcp-server-stripe` | no | yes | **no** | signalled, while `@stripe/mcp` — the same service, launched differently — is not |
+| `pm2`, `next-server` | no | yes | **no** | a dev server in an orphaned group is signalled, though pattern-based cleanup spares it |
+
+Two defects follow directly, and both were confirmed by running the shipped functions:
+
+**A runaway shared MCP is never actually signalled.** `_cc_guard_runaway_protected_pids` selects it, `_claude_pgid_kill` skips it. Worse, `rkilled` increments and the tree RSS is added to `rfreed` regardless of delivery, and a notification fires per candidate — so `claude-guard` reports `Reaped N runaway protected process(es), freed ~X MB` for processes still burning CPU. This is precisely the failure mode the runaway phase was built for: `CLAUDE.md` records that Cloudflare's MCP server is deliberately left off the whitelist because it pins ~100% CPU for hours.
+
+**A stuck system scanner is signalled.** Nothing in runaway selection consults `_cc_reaper_is_immutable_cmd`, so Bitdefender at 80% CPU for an hour is SIGTERM-ed after the grace window.
+
+Separately, `_claude_tree_rss` divides each member's RSS by 1024 before adding, so a tree is undercounted by roughly 0.5 MB per process, and it stops after grandchildren. Measured on four live sessions: 2–4 MB from truncation, 0–1 MB from depth.
+
+## What Changes
+
+- Add `_cc_reaper_protection_class`, returning `immutable`, `shared`, or `none` for a command line. It becomes the single owner of "how protected is this process", and the three paths consult it instead of three separate lists.
+- Runaway selection SHALL skip `immutable`. System scanners stop being candidates.
+- Runaway SHALL signal the candidate it selected, crossing the shared-service exemption for that PID only. Other members of its process group keep their protection.
+- Runaway counters SHALL report processes actually signalled, not processes considered.
+- `_claude_tree_rss` SHALL sum in kilobytes and convert once, and SHALL walk the whole descendant tree.
+
+Not in scope: process-group cleanup keeps signalling every non-protected member on membership alone. The group is the unit — its leader is an orphaned session, so the group is a corpse, and requiring per-member staleness would leave half-dead groups behind.
+
+## Capabilities
+
+### New Capabilities
+
+_None._
+
+### Modified Capabilities
+
+- `agent-process-reapers`: protection becomes one classification with three call sites; runaway gains an immutable exclusion and a forced signal for its own target.
+- `rss-threshold-reaper`: tree RSS becomes a full-depth sum converted once.
+
+## Impact
+
+- `shell/claude-cleanup.sh`: new `_cc_reaper_protection_class`; `_cc_reaper_is_protected_cmd`, `_cc_reaper_is_direct_cleanup_protected`, `_claude_pgid_kill`, `_cc_guard_runaway_protected_pids`, and `_claude_tree_rss` all change.
+- Behavior, in both directions:
+  - **Fewer kills**: system scanners leave the runaway candidate set; `mcp-server-stripe`, `pm2`, and `next-server` gain the group-kill protection they already had elsewhere.
+  - **More kills**: a runaway shared MCP is now genuinely terminated instead of being reported as such.
+  - Sessions cross `CC_MAX_RSS_MB` a few MB earlier, since tree RSS stops undercounting.
+- Reported counts change meaning: they become deliveries rather than intentions, so a run that previously claimed to free memory may now report zero. That is the honest number.

--- a/openspec/changes/unify-protection-classes/specs/agent-process-reapers/spec.md
+++ b/openspec/changes/unify-protection-classes/specs/agent-process-reapers/spec.md
@@ -1,0 +1,115 @@
+## ADDED Requirements
+
+### Requirement: One protection classification owns all three paths
+The system SHALL classify a command line into exactly one protection class via
+`_cc_reaper_protection_class`, and every cleanup path SHALL consult that classification rather
+than its own list.
+
+| Class | Meaning |
+|---|---|
+| `immutable` | System processes, cc-reaper's own scripts and app binary, ordinary Chrome, Codex UI helpers. Never signalled by any path. |
+| `shared` | Long-running services other work depends on: shared MCP servers, dev servers, process managers, and whitelisted applications. |
+| `none` | Everything else. |
+
+Each path SHALL apply the class as follows:
+
+| Path | `immutable` | `shared` | `none` |
+|---|---|---|---|
+| Pattern-based cleanup | never | exempt, unless a user `cleanup` rule covers it | family predicates decide |
+| Process-group cleanup | never | skipped | signalled on membership |
+| Runaway selection | never selected | selected | not selected — the phase only considers protected processes |
+| Runaway signalling | n/a | signalled, for the selected PID only | n/a |
+
+A user `protect` rule SHALL exempt a process on every path, and SHALL outrank a user `cleanup`
+rule.
+
+#### Scenario: Same service launched two ways
+- **WHEN** `npx -y @stripe/mcp` and `node …/.bin/mcp-server-stripe` are both running
+- **THEN** both SHALL classify as `shared`, and every path SHALL treat them identically
+
+#### Scenario: Dev server in an orphaned group
+- **WHEN** an orphaned process group contains a `pm2` or `next-server` process
+- **THEN** it SHALL classify as `shared` and SHALL be skipped by process-group cleanup, matching how pattern-based cleanup already spares it
+
+#### Scenario: Classification is total
+- **WHEN** any command line is classified
+- **THEN** exactly one of `immutable`, `shared`, or `none` SHALL be returned
+
+### Requirement: Runaway never selects immutable processes
+Runaway selection SHALL exclude processes classified `immutable`. A stuck system scanner SHALL
+NOT be signalled by cc-reaper under any threshold.
+
+#### Scenario: Security software is stuck hot
+- **WHEN** `Bitdefender` sustains CPU ≥ `CC_RUNAWAY_CPU` for etime ≥ `CC_RUNAWAY_MIN`
+- **THEN** it SHALL NOT be selected, listed, or signalled
+
+#### Scenario: Spotlight indexing is stuck hot
+- **WHEN** `mdworker` or `mds_stores` meets the same thresholds
+- **THEN** neither SHALL be selected
+
+#### Scenario: Application is stuck hot
+- **WHEN** a `shared` application such as `ChatGPT.app` meets the thresholds
+- **THEN** it SHALL still be selected and signalled, because it is not `immutable`
+
+### Requirement: Runaway signals the process it selected
+When the runaway phase selects a PID, the signal stage SHALL signal that PID even when its class
+would otherwise exempt it. The exemption SHALL continue to apply to every other member of its
+process group.
+
+#### Scenario: Runaway shared MCP is terminated
+- **WHEN** `chrome-devtools-mcp` is selected as a runaway candidate
+- **THEN** it SHALL be signalled, rather than skipped as a shared service
+
+#### Scenario: Group siblings keep their protection
+- **WHEN** the selected runaway PID shares a process group with `context7-mcp`, which is not itself runaway
+- **THEN** `context7-mcp` SHALL NOT be signalled
+
+#### Scenario: User protect rule still wins
+- **WHEN** a user `protect` rule covers a process that meets the runaway thresholds
+- **THEN** it SHALL NOT be selected or signalled
+
+### Requirement: Runaway counters report deliveries
+The reaped count and freed total SHALL include only processes to which a signal was actually
+sent. A candidate that survives the signal stage SHALL NOT be counted, SHALL NOT contribute to
+the freed total, and SHALL NOT raise a notification claiming it was reaped.
+
+#### Scenario: Every candidate is signalled
+- **WHEN** two runaway candidates are selected and both are signalled
+- **THEN** the summary SHALL report two reaped
+
+#### Scenario: A candidate is exempted at the signal stage
+- **WHEN** a candidate is spared by a user `protect` rule discovered at the signal stage
+- **THEN** the summary SHALL NOT count it, and its tree RSS SHALL NOT be added to the freed total
+
+#### Scenario: Nothing is delivered
+- **WHEN** every candidate is spared at the signal stage
+- **THEN** the summary SHALL report zero reaped rather than a non-zero count
+
+## MODIFIED Requirements
+
+### Requirement: Protection covers the matched process, not its descendants
+Every protection test SHALL be applied to a process's own command line. Ancestry SHALL NOT be
+consulted: it neither protects a process nor exposes one. A process whose command matches a
+protected pattern is exempt no matter who spawned it, and a process spawned by a protected
+application gains no protection from that parent.
+
+Losing a parent's protection is not the same as becoming reapable. A process is reaped only when
+it also satisfies a path's own eligibility test — a family predicate, a user `cleanup` rule, or
+membership in an orphaned group. A helper matching none of those is left alone however detached
+and stale it is.
+
+Protection itself SHALL come from the single classification in "One protection classification
+owns all three paths". The three paths differ only in eligibility and in how they treat the
+`shared` class, never in what they consider protected.
+
+#### Scenario: Live descendant of a protected application
+- **WHEN** a `shared` application has spawned MCP servers that are still attached to it and below the stale threshold, and no orphaned group covers them
+- **THEN** they SHALL NOT be signalled, because they satisfy no family predicate on their own merits
+
+#### Scenario: Leaked descendant of a protected application
+- **WHEN** a `shared` application has leaked `npx`-spawned MCP servers that are detached, older than `CC_AGENT_STALE_MINUTES`, and classify as `none`
+- **THEN** they SHALL be reaped, because a leaked helper carries no marker of its parent
+
+#### Scenario: Leaked descendant is itself a shared service
+- **WHEN** the leaked descendant classifies as `shared` and no user rule covers it
+- **THEN** it SHALL be exempt from pattern-based and process-group cleanup, and SHALL be reachable only by the runaway phase

--- a/openspec/changes/unify-protection-classes/specs/rss-threshold-reaper/spec.md
+++ b/openspec/changes/unify-protection-classes/specs/rss-threshold-reaper/spec.md
@@ -1,0 +1,28 @@
+## MODIFIED Requirements
+
+### Requirement: Tree RSS calculation
+The system SHALL calculate tree RSS over the session process and **all** its descendants, to any
+depth.
+
+Member sizes SHALL be summed in kilobytes and converted to megabytes once, at the end. Truncating
+each member individually loses roughly 0.5 MB per process, which on a ten-process tree is several
+megabytes of silent undercount.
+
+Both corrections make tree RSS larger than before, so a session crosses `CC_MAX_RSS_MB` slightly
+earlier than it used to. The previous behaviour was an undercount, not a safety margin.
+
+#### Scenario: Session with MCP server children
+- **WHEN** a Claude session (PID 1000) has 3 child MCP servers each using 200 MB, and the session itself uses 500 MB
+- **THEN** tree RSS SHALL be calculated as 1100 MB
+
+#### Scenario: Members carry fractional megabytes
+- **WHEN** a session's own RSS is 4095 MB plus 1023 KB and its single child holds 1 KB
+- **THEN** tree RSS SHALL be 4096 MB, because members are summed in kilobytes before conversion
+
+#### Scenario: Great-grandchild process
+- **WHEN** a session's grandchild has spawned a further child of its own
+- **THEN** that process's RSS SHALL be included in tree RSS
+
+#### Scenario: Deep wrapper chain
+- **WHEN** a session runs behind a chain such as CLI → `npm` → shell → server
+- **THEN** every process in that chain SHALL contribute to tree RSS

--- a/openspec/changes/unify-protection-classes/tasks.md
+++ b/openspec/changes/unify-protection-classes/tasks.md
@@ -1,0 +1,39 @@
+## 1. Single classification
+
+- [x] 1.1 Add `_cc_reaper_protection_class` returning `immutable` / `shared` / `none`
+- [x] 1.2 Fold the three existing lists into it, reconciling `mcp-server-stripe` with `@stripe/mcp` and giving dev servers/`pm2` the same class everywhere
+- [x] 1.3 Re-express `_cc_reaper_is_protected_cmd` and `_cc_reaper_is_direct_cleanup_protected` in terms of the class, so no caller changes shape
+- [x] 1.4 Replace `MCP_WHITELIST` in `_claude_pgid_kill` with the class
+
+## 2. Runaway correctness
+
+- [x] 2.1 Exclude `immutable` from `_cc_guard_runaway_protected_pids`
+- [x] 2.2 Signal the selected runaway PID even when its class is `shared`, sparing other group members
+- [x] 2.3 Count and total only what was actually signalled; suppress the per-candidate notification when nothing was sent
+
+## 3. Tree RSS
+
+- [x] 3.1 Sum member RSS in kilobytes, convert once
+- [x] 3.2 Walk the full descendant tree instead of stopping at grandchildren
+- [x] 3.3 Measure the added cost on a live session tree
+
+## 4. Regression proof
+
+- [x] 4.1 Classification table test: every representative command from the proposal, asserting its class
+- [x] 4.2 Assert the three paths agree on protection for the same command
+- [x] 4.3 Runaway: immutable excluded, shared selected, user `protect` still exempt
+- [x] 4.4 Runaway signalling: selected PID signalled, group sibling spared
+- [x] 4.5 Counters: all delivered, partially delivered, none delivered
+- [x] 4.6 Tree RSS: fractional members, great-grandchild, deep chain
+- [x] 4.7 Existing suite stays green under bash and zsh
+
+## 5. Failure and rollback proof (High-risk)
+
+- [x] 5.1 Prove no signal is sent to any `immutable` command on any path
+- [x] 5.2 Prove a user `protect` rule still exempts on all three paths
+- [x] 5.3 Dry-run the whole reaper against the live host and diff the candidate set against the current implementation, explaining every difference
+- [x] 5.4 Confirm revert is a single `git revert` with no state migration
+
+## 6. Documentation
+
+- [x] 6.1 Update `CLAUDE.md`: the classification, the runaway exclusion, and that counters mean deliveries

--- a/shell/claude-cleanup.sh
+++ b/shell/claude-cleanup.sh
@@ -6,9 +6,30 @@ _cc_reaper_protected_pattern() {
   echo "node.*(dev-server|http-server|next.*server)|pm2|npm exec @supabase|mcp-server-supabase|supabase.*mcp|npm exec @stripe|@stripe/mcp|mcp-server-stripe|stripe.*mcp|claude-mem|chroma-mcp|context7|context7-mcp|chrome-devtools-mcp|mcp-remote|sequentialthinking|sequential-thinking|codex.*mcp|ChatGPT\\.app|cmux\\.app|Bitdefender|mdworker|mds_stores"
 }
 
-_cc_reaper_is_protected_cmd() {
+# Single owner of "how protected is this process". Three cleanup paths used to
+# carry their own list and disagreed: a runaway shared MCP was selected by one
+# and skipped by another, `mcp-server-stripe` was protected where `@stripe/mcp`
+# was not, and a stuck system scanner was reachable by the runaway phase.
+#
+#   immutable — never signalled by any path
+#   shared    — a long-running service other work depends on
+#   none      — everything else
+#
+# Immutable is tested first, so a system scanner named in both sets classifies
+# immutable rather than shared.
+_cc_reaper_protection_class() {
   local cmd=$1
-  echo "$cmd" | grep -qE "$(_cc_reaper_protected_pattern)"
+  if _cc_reaper_is_immutable_cmd "$cmd"; then
+    echo immutable
+  elif echo "$cmd" | grep -qE "$(_cc_reaper_protected_pattern)"; then
+    echo shared
+  else
+    echo none
+  fi
+}
+
+_cc_reaper_is_protected_cmd() {
+  [ "$(_cc_reaper_protection_class "$1")" = shared ]
 }
 
 _cc_reaper_rules_file() {
@@ -391,29 +412,37 @@ _claude_process_fds() {
 }
 
 # Calculate tree RSS (MB) for a given PID: process + children + grandchildren
+# Total RSS of a process tree, in whole megabytes.
+#
+# Summed in kilobytes and converted once. Dividing each member first truncated
+# roughly 0.5 MB per process, which on a ten-process tree silently undercounted
+# the total by several megabytes. The walk is full-depth for the same reason:
+# stopping at grandchildren missed anything behind a wrapper chain such as
+# CLI -> npm -> shell -> server.
+#
+# One `ps` builds the whole table and awk walks it, rather than a `pgrep` per
+# node — that is cheaper than even the two-level version it replaces.
 _claude_tree_rss() {
   local pid=$1
-  local rss=$(ps -p "$pid" -o rss= 2>/dev/null | tr -d ' ')
-  [ -z "$rss" ] && echo 0 && return
-  local tree_mb=$((rss / 1024))
-
-  local children=()
-  while IFS= read -r cpid; do
-    [ -z "$cpid" ] && continue
-    children+=("$cpid")
-    local crss=$(ps -p "$cpid" -o rss= 2>/dev/null | tr -d ' ')
-    [ -n "$crss" ] && tree_mb=$((tree_mb + crss / 1024))
-  done < <(pgrep -P "$pid" 2>/dev/null)
-
-  for cpid in "${children[@]}"; do
-    while IFS= read -r gcpid; do
-      [ -z "$gcpid" ] && continue
-      local gcrss=$(ps -p "$gcpid" -o rss= 2>/dev/null | tr -d ' ')
-      [ -n "$gcrss" ] && tree_mb=$((tree_mb + gcrss / 1024))
-    done < <(pgrep -P "$cpid" 2>/dev/null)
-  done
-
-  echo "$tree_mb"
+  ps -eo pid=,ppid=,rss= 2>/dev/null | awk -v root="$pid" '
+    $1 ~ /^[0-9]+$/ && $3 ~ /^[0-9]+$/ {
+      kids[$2] = kids[$2] " " $1
+      rss[$1] = $3
+    }
+    END {
+      if (!(root in rss)) { print 0; exit }
+      queue[1] = root; n = 1; i = 1; total = 0
+      while (i <= n) {
+        p = queue[i]; i++
+        if (p in seen) continue
+        seen[p] = 1
+        total += rss[p]
+        m = split(kids[p], ch, " ")
+        for (j = 1; j <= m; j++) { n++; queue[n] = ch[j] }
+      }
+      printf "%d\n", total / 1024
+    }
+  '
 }
 
 # Process table carrying PID, TTY, and executable name only. `comm` holds the
@@ -697,28 +726,45 @@ claude-sessions() {
   fi
 }
 
-# Kill a session's process group while preserving whitelisted MCP servers
-# Usage: _claude_pgid_kill <pid>
+# Kill a session's process group, sparing immutable processes, shared services,
+# and anything a user `protect` rule covers. Prints the number of processes
+# actually signalled, so callers can report deliveries rather than intentions.
+#
+# `force_target` makes the named PID itself bypass the `shared` exemption — the
+# runaway phase uses it to terminate a shared service that is stuck hot, which
+# is the one case where reclaiming it is the point. It never bypasses the
+# immutable class or a user `protect` rule, and never applies to the target's
+# group siblings.
+#
+# Usage: _claude_pgid_kill <pid> [force_target]
 _claude_pgid_kill() {
   local target_pid=$1
-  local MCP_WHITELIST="supabase|@stripe/mcp|context7|context7-mcp|claude-mem|chroma-mcp|chrome-devtools-mcp|mcp-remote|sequentialthinking|sequential-thinking|codex.*mcp"
+  local force_target=${2:-0}
+  local signalled=0
   local target_cmd=""
   target_cmd=$(ps -o command= -p "$target_pid" 2>/dev/null)
-  _cc_reaper_has_user_rule protect "$target_cmd" && return 1
+  _cc_reaper_has_user_rule protect "$target_cmd" && { echo 0; return 1; }
+  [ "$(_cc_reaper_protection_class "$target_cmd")" = immutable ] && { echo 0; return 1; }
+
   local pgid=$(ps -o pgid= -p "$target_pid" 2>/dev/null | tr -d ' ')
   if [ -n "$pgid" ] && [ "$pgid" != "0" ]; then
     while IFS= read -r pid; do
       [ -z "$pid" ] && continue
       local pid_cmd=$(ps -o command= -p "$pid" 2>/dev/null)
       _cc_reaper_has_user_rule protect "$pid_cmd" && continue
-      if echo "$pid_cmd" | grep -qE "$MCP_WHITELIST"; then
-        continue
+      local class=""
+      class=$(_cc_reaper_protection_class "$pid_cmd")
+      [ "$class" = immutable ] && continue
+      if [ "$class" = shared ]; then
+        # Only the explicitly selected target crosses this exemption.
+        { [ "$force_target" = 1 ] && [ "$pid" = "$target_pid" ]; } || continue
       fi
-      _cc_reaper_kill_pid "$pid"
+      _cc_reaper_kill_pid "$pid" && signalled=$((signalled + 1))
     done < <(ps -eo pid,pgid 2>/dev/null | awk -v pgid="$pgid" '$2 == pgid {print $1}')
   else
-    _cc_reaper_kill_pid "$target_pid"
+    _cc_reaper_kill_pid "$target_pid" && signalled=1
   fi
+  echo "$signalled"
 }
 
 # Automatic session guard: kills bloated (RSS threshold) and idle sessions
@@ -759,7 +805,11 @@ _cc_guard_runaway_protected_pids() {
   local min_seconds=$((min_minutes * 60))
   ps -axo pid=,etime=,%cpu=,command= 2>/dev/null | while read -r pid etime cpu rest; do
     [ -z "$pid" ] && continue
-    echo "$rest" | grep -qE "$protected_pattern" || continue
+    # Only shared services are candidates. Immutable processes — system
+    # scanners, cc-reaper itself, ordinary Chrome — are never signalled, however
+    # hot they get: SIGTERM-ing security software or a Spotlight reindex costs
+    # more than the CPU it would reclaim.
+    [ "$(_cc_reaper_protection_class "$rest")" = shared ] || continue
     _cc_reaper_has_user_rule protect "$rest" && continue
     awk -v a="$cpu" -v b="$cpu_threshold" 'BEGIN { exit !(a+0 >= b+0) }' || continue
     local secs=""
@@ -819,10 +869,17 @@ claude-guard() {
           [ -z "$rpid" ] && continue
           local rrss=""
           rrss=$(_claude_tree_rss "$rpid" 2>/dev/null || echo 0)
-          _claude_pgid_kill "$rpid" >/dev/null 2>&1
-          rkilled=$((rkilled + 1))
-          rfreed=$((rfreed + ${rrss:-0}))
-          osascript -e "display notification \"Reaped runaway PID $rpid (CPU ${rcpu}%, etime ${retime})\" with title \"Claude Guard\" subtitle \"Runaway protected process\"" 2>/dev/null &
+          # force_target: a runaway shared service is exactly what this phase
+          # exists to reclaim, so the selected PID crosses the shared exemption.
+          local rsent=""
+          rsent=$(_claude_pgid_kill "$rpid" 1 2>/dev/null)
+          if [ "${rsent:-0}" -gt 0 ]; then
+            rkilled=$((rkilled + 1))
+            rfreed=$((rfreed + ${rrss:-0}))
+            osascript -e "display notification \"Reaped runaway PID $rpid (CPU ${rcpu}%, etime ${retime})\" with title \"Claude Guard\" subtitle \"Runaway protected process\"" 2>/dev/null &
+          else
+            echo "  PID $rpid was spared at the signal stage; not counted."
+          fi
         done <<< "$runaway_lines"
         echo "  Reaped $rkilled runaway protected process(es), freed ~${rfreed} MB"
       fi
@@ -907,7 +964,7 @@ claude-guard() {
       if $dry_run; then
         echo "  [DRY-RUN] Would kill PID $fpid (FDs: $ffds, threshold: $max_fd)"
       else
-        _claude_pgid_kill "$fpid"
+        _claude_pgid_kill "$fpid" >/dev/null
         echo "  Killed PID $fpid (FDs: $ffds, threshold: $max_fd)"
         killed=$((killed + 1))
         freed_mb=$((freed_mb + frss))
@@ -928,7 +985,7 @@ claude-guard() {
         echo "  [DRY-RUN] Would kill PID $bpid (tree RSS: ${brss} MB, threshold: ${max_rss_mb} MB)"
       else
         # Kill session group, preserving whitelisted MCP servers
-        _claude_pgid_kill "$bpid"
+        _claude_pgid_kill "$bpid" >/dev/null
         echo "  Killed PID $bpid (tree RSS: ${brss} MB, threshold: ${max_rss_mb} MB)"
         killed=$((killed + 1))
         freed_mb=$((freed_mb + brss))
@@ -957,7 +1014,7 @@ claude-guard() {
         echo "  [DRY-RUN] Would kill PID $ipid (idle ${ietime}, tree RSS: ${irss} MB)"
       else
         # Kill session group, preserving whitelisted MCP servers
-        _claude_pgid_kill "$ipid"
+        _claude_pgid_kill "$ipid" >/dev/null
         echo "  Killed PID $ipid (idle ${ietime}, tree RSS: ${irss} MB)"
         killed=$((killed + 1))
         freed_mb=$((freed_mb + irss))

--- a/tests/protection-classes.sh
+++ b/tests/protection-classes.sh
@@ -1,0 +1,206 @@
+#!/usr/bin/env bash
+# Pins the single protection classification and the runaway corrections it
+# enables. See openspec/specs/agent-process-reapers/spec.md.
+#
+# Every kill path is exercised through _CC_REAPER_DRY_RUN, so no signal is ever
+# sent; `ps` is stubbed where a fixed process table is needed.
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+source "$ROOT_DIR/shell/claude-cleanup.sh"
+
+failures=0
+pass() { printf "ok - %s\n" "$1"; }
+fail() { printf "not ok - %s\n" "$1"; failures=$((failures + 1)); }
+
+tmp_dir=$(mktemp -d "${TMPDIR:-/tmp}/cc-reaper-class-test.XXXXXX")
+trap 'rm -rf "$tmp_dir"' EXIT
+rules_file="$tmp_dir/process-rules.tsv"
+: > "$rules_file"
+export CC_REAPER_RULES_FILE="$rules_file"
+
+# ─── Classification ────────────────────────────────────────────────────────
+
+expect_class() {
+  local want=$1 cmd=$2
+  local got
+  got=$(_cc_reaper_protection_class "$cmd")
+  if [ "$got" = "$want" ]; then
+    pass "$want: ${cmd:0:52}"
+  else
+    fail "${cmd:0:52} (want $want, got $got)"
+  fi
+}
+
+expect_class immutable "/Library/Bitdefender/AVP/product/bin/BDLDaemon"
+expect_class immutable "/System/Library/.../Support/mdworker_shared"
+expect_class immutable "/System/Library/.../Support/mds_stores"
+expect_class immutable "/x/shell/claude-cleanup.sh"
+expect_class immutable "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome"
+expect_class immutable "/Users/me/.codex/computer-use/Codex Computer Use.app/x/SkyComputerUseService"
+
+expect_class shared "/Applications/ChatGPT.app/Contents/Resources/codex -c x"
+expect_class shared "/Applications/cmux.app/Contents/MacOS/cmux"
+expect_class shared "npx chrome-devtools-mcp@latest --autoConnect"
+expect_class shared "npm exec @upstash/context7-mcp"
+expect_class shared "npx -y @supabase/mcp-server-supabase@0.5.10 --read-only"
+expect_class shared "npx -y mcp-sequentialthinking-tools"
+expect_class shared "node /x/next-server --port 3000"
+expect_class shared "pm2 God Daemon"
+
+# Regression: the same service launched two ways classified differently before,
+# because the group-kill list held `@stripe/mcp` but not `mcp-server-stripe`.
+expect_class shared "npx -y @stripe/mcp"
+expect_class shared "node /x/node_modules/.bin/mcp-server-stripe"
+
+expect_class none "node /x/_npx/a/node_modules/.bin/mcp-server-tauri"
+expect_class none "/opt/unrelated-helper --serve"
+
+# ─── The three paths agree on protection ───────────────────────────────────
+
+for cmd in "/Library/Bitdefender/AVP/product/bin/BDLDaemon" \
+           "npx chrome-devtools-mcp@latest" \
+           "node /x/.bin/mcp-server-tauri"; do
+  class=$(_cc_reaper_protection_class "$cmd")
+  direct=$(_cc_reaper_is_direct_cleanup_protected "$cmd" && echo protected || echo open)
+  want=$([ "$class" = none ] && echo open || echo protected)
+  if [ "$direct" = "$want" ]; then
+    pass "group-kill protection agrees with class ($class): ${cmd:0:40}"
+  else
+    fail "group-kill disagrees with class ($class): ${cmd:0:40}"
+  fi
+done
+
+# ─── Runaway selection ─────────────────────────────────────────────────────
+
+runaway_with() {
+  local table=$1
+  ( ps() {
+      if [ "$*" = "-axo pid=,etime=,%cpu=,command=" ]; then printf '%s' "$table"; else command ps "$@"; fi
+    }
+    _cc_guard_runaway_protected_pids 80 60 )
+}
+
+out=$(runaway_with "901 03:00:00 99.0 /Library/Bitdefender/AVP/product/bin/BDLDaemon
+")
+[ -z "$out" ] && pass "runaway skips Bitdefender" || fail "runaway selected Bitdefender"
+
+out=$(runaway_with "902 03:00:00 99.0 /System/Library/x/mdworker_shared
+")
+[ -z "$out" ] && pass "runaway skips mdworker" || fail "runaway selected mdworker"
+
+out=$(runaway_with "903 03:00:00 99.0 npx chrome-devtools-mcp@latest --autoConnect
+")
+printf '%s' "$out" | grep -q '^903' && pass "runaway selects a shared MCP" || fail "runaway missed a shared MCP"
+
+out=$(runaway_with "904 03:00:00 99.0 /Applications/ChatGPT.app/Contents/Resources/codex
+")
+printf '%s' "$out" | grep -q '^904' && pass "runaway selects a shared application" || fail "runaway missed a shared application"
+
+out=$(runaway_with "905 03:00:00 99.0 node /x/.bin/mcp-server-tauri
+")
+[ -z "$out" ] && pass "runaway ignores an unprotected process" || fail "runaway selected an unprotected process"
+
+printf 'protect\tchrome-devtools-mcp\n' > "$rules_file"
+out=$(runaway_with "906 03:00:00 99.0 npx chrome-devtools-mcp@latest
+")
+[ -z "$out" ] && pass "user protect rule keeps a process out of runaway" || fail "user protect rule ignored by runaway"
+: > "$rules_file"
+
+# ─── Runaway signalling ────────────────────────────────────────────────────
+# Group 500 holds the runaway MCP (500) and an idle sibling MCP (501).
+
+kill_with() {
+  local target=$1 force=$2
+  ( ps() { case "$*" in
+        "-o command= -p 500") echo "npx chrome-devtools-mcp@latest --autoConnect" ;;
+        "-o command= -p 501") echo "npm exec @upstash/context7-mcp" ;;
+        "-o command= -p 502") echo "node /x/.bin/mcp-server-tauri" ;;
+        "-o pgid= -p "*)      echo " 500" ;;
+        "-eo pid,pgid")       printf "500 500\n501 500\n502 500\n" ;;
+        *) command ps "$@" ;; esac; }
+    _CC_REAPER_DRY_RUN=1 _claude_pgid_kill "$target" "$force" 2>&1 || true )
+}
+
+out=$(kill_with 500 1)
+if printf '%s' "$out" | grep -q 'Would kill PID 500' \
+   && ! printf '%s' "$out" | grep -q 'Would kill PID 501'; then
+  pass "runaway target is signalled, shared sibling is spared"
+else
+  fail "runaway force-target behaviour wrong: $(printf '%s' "$out" | tr '\n' ' ')"
+fi
+
+printf '%s' "$out" | grep -q 'Would kill PID 502' \
+  && pass "unprotected group member is still signalled" \
+  || fail "unprotected group member was spared"
+
+out=$(kill_with 500 0)
+printf '%s' "$out" | grep -q 'Would kill PID 500' \
+  && fail "shared target signalled without force" \
+  || pass "shared target is spared when not forced"
+
+# ─── Delivery counting ─────────────────────────────────────────────────────
+
+count_of() { printf '%s' "$1" | tail -1; }
+
+out=$(kill_with 500 1)
+[ "$(count_of "$out")" = 2 ] && pass "count reports two deliveries" || fail "count wrong: $(count_of "$out")"
+
+printf 'protect\tchrome-devtools-mcp\n' > "$rules_file"
+out=$(kill_with 500 1 || true)
+[ "$(count_of "$out")" = 0 ] && pass "protected target reports zero deliveries" || fail "protected target counted: $(count_of "$out")"
+: > "$rules_file"
+
+kill_immutable() {
+  ( ps() { case "$*" in
+        "-o command= -p 600") echo "/System/Library/x/mdworker_shared" ;;
+        *) command ps "$@" ;; esac; }
+    _CC_REAPER_DRY_RUN=1 _claude_pgid_kill 600 1 2>&1 || true )
+}
+out=$(kill_immutable)
+[ "$(count_of "$out")" = 0 ] && pass "immutable target reports zero deliveries" || fail "immutable target counted"
+
+# ─── Tree RSS ──────────────────────────────────────────────────────────────
+
+rss_table() {
+  ( ps() {
+      if [ "$*" = "-eo pid=,ppid=,rss=" ]; then printf '%s' "$TABLE"; else command ps "$@"; fi
+    }
+    _claude_tree_rss "$1" )
+}
+
+# 4095 MB + 1023 KB parent, 1 KB child: truncating each member first gives 4095.
+TABLE="1000 1 4194303
+1001 1000 1
+"
+got=$(rss_table 1000)
+[ "$got" = 4096 ] && pass "members are summed before conversion" || fail "fractional sum wrong: $got"
+
+# Great-grandchild must be counted.
+TABLE="2000 1 1048576
+2001 2000 1048576
+2002 2001 1048576
+2003 2002 1048576
+"
+got=$(rss_table 2000)
+[ "$got" = 4096 ] && pass "full depth is walked" || fail "deep tree wrong: $got"
+
+# An unrelated tree must not leak in.
+TABLE="3000 1 1048576
+3001 3000 1048576
+4000 1 1048576
+"
+got=$(rss_table 3000)
+[ "$got" = 2048 ] && pass "unrelated processes are excluded" || fail "unrelated tree leaked: $got"
+
+TABLE="5000 1 1024
+"
+got=$(rss_table 9999)
+[ "$got" = 0 ] && pass "missing PID yields zero" || fail "missing PID wrong: $got"
+
+if [ "$failures" -gt 0 ]; then
+  printf "%s validation failure(s)\n" "$failures"
+  exit 1
+fi
+
+printf "protection class validation passed\n"


### PR DESCRIPTION
Stacked on #7 — review that first. This is the behavior half; #7 was documentation only.

## The root cause

cc-reaper decided what it may signal from **three lists that had drifted apart**:

| Predicate | Used by |
|---|---|
| `_cc_reaper_protected_pattern` | pattern cleanup, runaway **selection** |
| `_cc_reaper_is_direct_cleanup_protected` | process-group cleanup |
| `MCP_WHITELIST`, local to `_claude_pgid_kill` | the **signal** stage |

Measured against representative commands, four disagreements:

| Command | immutable | protected | group list | Consequence |
|---|---|---|---|---|
| `Bitdefender`, `mdworker`, `mds_stores` | yes | yes | no | runaway selected **and signalled** a system scanner |
| `chrome-devtools-mcp`, `context7-mcp` | no | yes | yes | runaway selected, signal stage skipped — **reported reaped, still running** |
| `mcp-server-stripe` | no | yes | no | signalled, while `@stripe/mcp` — same service — was not |
| `pm2`, `next-server` | no | yes | no | a dev server in an orphaned group was signalled |

## What changes

`_cc_reaper_protection_class` returns `immutable` / `shared` / `none` and becomes the single owner of the decision. Immutable is tested first, so a scanner named in both sets classifies immutable rather than shared.

| Path | `immutable` | `shared` | `none` |
|---|---|---|---|
| Pattern-based | never | exempt, unless a user `cleanup` rule covers it | family predicates decide |
| Process-group | never | skipped | signalled on membership |
| Runaway | never selected | selected, **and signalled** | not selected |

**Runaway now works.** It skips immutable, so security software and Spotlight reindexing are out of reach whatever their CPU. It passes `force_target` for the PID it selected, so a stuck shared MCP is genuinely terminated while its group siblings keep their exemption. That failure mode is the reason the phase exists — `CLAUDE.md` records Cloudflare's MCP pinning ~100% CPU for hours.

**Counts became honest.** `_claude_pgid_kill` returns how many processes it signalled. A candidate spared at the signal stage is no longer counted, adds nothing to the freed total, and raises no notification. The summary can now report zero.

**Tree RSS** sums the full descendant tree in kilobytes and converts once, from a single `ps` walked in awk. Corrected totals are 2–10 MB higher on the live sessions, and the single-pass form runs in **28 ms against 156 ms** for the two-level version it replaces.

## Deliberately unchanged

Process-group cleanup still signals every non-protected member on membership alone. The group's leader is an orphaned session, so the group is a corpse; requiring per-member staleness would leave half-dead groups behind.

## Proof

- `tests/protection-classes.sh`: 37 checks, green under bash and zsh. 14 test scripts green; `bash -n` and `zsh -n` on all three entry points.
- **Live candidate diff**: 24 PIDs shared with the previous implementation, one extra — a tauri MCP ChatGPT spawned between the two runs. Both versions classify it identically, so the candidate set is unchanged.
- **No signal reaches an immutable command on any path**:

```
BDLDaemon         pattern=exempt  group sent=0  runaway=not selected
mdworker_shared   pattern=exempt  group sent=0  runaway=not selected
claude-cleanup.sh pattern=exempt  group sent=0  runaway=not selected
```

- **A user `protect` rule exempts on all three paths**: pattern exempt, group sent 0, runaway not selected.
- **Rollback**: one `git revert`. No state, no config, no new environment variables.

Spec: `openspec/changes/unify-protection-classes/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013fb4GVnqAHVvncpMUePocW