### PR TITLE
fix: cc-monitor scan exceeds companion app's 30s timeout on high process counts

### DIFF
--- a/shell/cc-monitor.sh
+++ b/shell/cc-monitor.sh
@@ -170,61 +170,90 @@ _cc_monitor_is_runaway() {
     && [ "$elapsed_seconds" -ge "$((etime_threshold * 60))" ]
 }
 
-_cc_monitor_protected_pattern() {
-  echo "node.*(dev-server|http-server|next.*server)|pm2|npm exec @supabase|mcp-server-supabase|supabase.*mcp|npm exec @stripe|@stripe/mcp|mcp-server-stripe|stripe.*mcp|claude-mem|chroma-mcp|context7|context7-mcp|chrome-devtools-mcp|mcp-remote|sequentialthinking|sequential-thinking|codex.*mcp|ChatGPT\\.app|cmux\\.app|Bitdefender|mdworker|mds_stores|CCReaper|Codex Computer Use\\.app|SkyComputerUseService"
-}
+# Precomputed once at source time (not per-call) since this string is static.
+# PERF: this and every predicate below used to run `printf '%s\n' "$cmd" | grep -qE "..."`,
+# forking 2 processes per check. _cc_monitor_enrich_findings calls these ~15-20x per
+# process row; on a machine with hundreds of live processes (many concurrent Claude
+# Code sessions, each with its own MCP fleet) that's thousands of forks, which is what
+# pushed cc-monitor well past the companion app's 30s scan timeout. `[[ $cmd =~ ... ]]`
+# is bash's native (fork-free) regex match — same ERE syntax as grep -E, same behavior.
+_CC_MONITOR_PROTECTED_PATTERN="node.*(dev-server|http-server|next.*server)|pm2|npm exec @supabase|mcp-server-supabase|supabase.*mcp|npm exec @stripe|@stripe/mcp|mcp-server-stripe|stripe.*mcp|claude-mem|chroma-mcp|context7|context7-mcp|chrome-devtools-mcp|mcp-remote|sequentialthinking|sequential-thinking|codex.*mcp|ChatGPT\.app|cmux\.app|Bitdefender|mdworker|mds_stores|CCReaper|Codex Computer Use\.app|SkyComputerUseService"
+
+# NOTE ON PORTABILITY: every pattern below is precomputed into its own variable and
+# matched via `[[ $cmd =~ $VAR ]]`, never written as a bare literal after `=~`. This
+# script is sourced under both bash (CLIService/tests) and zsh (~/.zshrc, since these
+# are user-facing shell functions) — zsh's [[ ]] parser treats an unquoted `|` in an
+# inline pattern as a pipe operator and fails with "parse error near `|'"; routing the
+# same string through a variable first sidesteps that in both shells.
+_CC_MONITOR_PROTECTED_PATTERN="node.*(dev-server|http-server|next.*server)|pm2|npm exec @supabase|mcp-server-supabase|supabase.*mcp|npm exec @stripe|@stripe/mcp|mcp-server-stripe|stripe.*mcp|claude-mem|chroma-mcp|context7|context7-mcp|chrome-devtools-mcp|mcp-remote|sequentialthinking|sequential-thinking|codex.*mcp|ChatGPT\.app|cmux\.app|Bitdefender|mdworker|mds_stores|CCReaper|Codex Computer Use\.app|SkyComputerUseService"
+_CC_MONITOR_AGENT_BROWSER_PATTERN="agent-browser-darwin-arm64|Google Chrome for Testing.*agent-browser-chrome-|agent-browser-chrome-"
+_CC_MONITOR_PUPPETEER_CHROME_PATTERN="puppeteer_dev_chrome_profile-"
+_CC_MONITOR_CODEX_APP_SERVER_PATTERN="codex app-server|app-server-broker"
+_CC_MONITOR_CODEX_AGENT_PATTERN="node /usr/local/bin/codex( --yolo| resume|$)|@openai/codex.*/codex/codex( --yolo| resume|$)|/codex/codex( --yolo| resume|$)|(^|/)codex( --yolo| resume|$)"
+_CC_MONITOR_CLAUDE_AGENT_PATTERN="claude.*stream-json|claude.*--session-id|claude --dangerously"
+_CC_MONITOR_AGENT_MCP_PATTERN="npm exec @upstash/context7-mcp|context7-mcp|chrome-devtools-mcp|npm exec mcp-remote|mcp-remote|npm exec mcp-|npx.*mcp-server"
+_CC_MONITOR_DEV_SERVER_PATTERN="react-scripts/scripts/start|react-scripts start|next dev|vite( --host| --port|$)|webpack-dev-server|astro dev|node.*(dev-server|http-server|next.*server)|npm run dev|pnpm dev|yarn dev"
+_CC_MONITOR_SYSTEM_PATTERN="WindowServer|kernel_task|coreaudiod|syspolicyd|mdworker|mds_stores|Spotlight|Bitdefender|com\.apple\.|/System/Library/|PerfPowerServices|BTLEServer|bluetoothd|UniversalControl|UserNotificationCenter|BiomeAgent|accountsd|locationd|logd|opendirectoryd|replayd|BetterSnapTool|netdisk_service"
+_CC_MONITOR_CODEX_UI_HELPER_PATTERN="Codex Computer Use\.app|SkyComputerUseService"
+_CC_MONITOR_SELF_PATTERN="cc-monitor\.sh( |$)|CCReaper\.app/Contents/MacOS/CCReaper( |$)|/CCReaper( |$)"
+_CC_MONITOR_NORMAL_CHROME_PATTERN="Google Chrome\.app|Google Chrome Helper|/Google Chrome( |$)|Chromium\.app"
+_CC_MONITOR_EDITOR_PATTERN="Cursor Helper|Cursor\.app|Visual Studio Code|Code Helper|/Code\.app|/Cursor\.app"
+_CC_MONITOR_CMUX_PATTERN="(^|/)cmux( |$)|cmux\.app"
+_CC_MONITOR_CHATGPT_PATTERN="ChatGPT\.app"
+_CC_MONITOR_CODEX_UI_LABEL_PATTERN="SkyComputerUseService|Codex Computer Use\.app"
+_CC_MONITOR_SELF_LABEL_PATTERN="CCReaper\.app/Contents/MacOS/CCReaper|(^|/)CCReaper( |$)"
 
 _cc_monitor_is_protected_cmd() {
   local cmd=$1
-  printf '%s\n' "$cmd" | grep -qE "$(_cc_monitor_protected_pattern)"
+  [[ $cmd =~ $_CC_MONITOR_PROTECTED_PATTERN ]]
 }
 
 _cc_monitor_is_agent_browser_cmd() {
   local cmd=$1
-  printf '%s\n' "$cmd" | grep -qE "agent-browser-darwin-arm64|Google Chrome for Testing.*agent-browser-chrome-|agent-browser-chrome-"
+  [[ $cmd =~ $_CC_MONITOR_AGENT_BROWSER_PATTERN ]]
 }
 
 _cc_monitor_is_puppeteer_chrome_cmd() {
   local cmd=$1
-  printf '%s\n' "$cmd" | grep -qE "puppeteer_dev_chrome_profile-"
+  [[ $cmd =~ $_CC_MONITOR_PUPPETEER_CHROME_PATTERN ]]
 }
 
 _cc_monitor_is_codex_agent_cmd() {
   local cmd=$1
-  if printf '%s\n' "$cmd" | grep -qE "codex app-server|app-server-broker"; then
+  if [[ $cmd =~ $_CC_MONITOR_CODEX_APP_SERVER_PATTERN ]]; then
     return 1
   fi
-  printf '%s\n' "$cmd" | grep -qE "node /usr/local/bin/codex( --yolo| resume|$)|@openai/codex.*/codex/codex( --yolo| resume|$)|/codex/codex( --yolo| resume|$)|(^|/)codex( --yolo| resume|$)"
+  [[ $cmd =~ $_CC_MONITOR_CODEX_AGENT_PATTERN ]]
 }
 
 _cc_monitor_is_claude_agent_cmd() {
   local cmd=$1
-  printf '%s\n' "$cmd" | grep -qE "claude.*stream-json|claude.*--session-id|claude --dangerously"
+  [[ $cmd =~ $_CC_MONITOR_CLAUDE_AGENT_PATTERN ]]
 }
 
 _cc_monitor_is_agent_mcp_cmd() {
   local cmd=$1
-  printf '%s\n' "$cmd" | grep -qE "npm exec @upstash/context7-mcp|context7-mcp|chrome-devtools-mcp|npm exec mcp-remote|mcp-remote|npm exec mcp-|npx.*mcp-server"
+  [[ $cmd =~ $_CC_MONITOR_AGENT_MCP_PATTERN ]]
 }
 
 _cc_monitor_is_dev_server_cmd() {
   local cmd=$1
-  printf '%s\n' "$cmd" | grep -qE "react-scripts/scripts/start|react-scripts start|next dev|vite( --host| --port|$)|webpack-dev-server|astro dev|node.*(dev-server|http-server|next.*server)|npm run dev|pnpm dev|yarn dev"
+  [[ $cmd =~ $_CC_MONITOR_DEV_SERVER_PATTERN ]]
 }
 
 _cc_monitor_is_system_cmd() {
   local cmd=$1
-  printf '%s\n' "$cmd" | grep -qE "WindowServer|kernel_task|coreaudiod|syspolicyd|mdworker|mds_stores|Spotlight|Bitdefender|com\\.apple\\.|/System/Library/|PerfPowerServices|BTLEServer|bluetoothd|UniversalControl|UserNotificationCenter|BiomeAgent|accountsd|locationd|logd|opendirectoryd|replayd|BetterSnapTool|netdisk_service"
+  [[ $cmd =~ $_CC_MONITOR_SYSTEM_PATTERN ]]
 }
 
 _cc_monitor_is_codex_ui_helper_cmd() {
   local cmd=$1
-  printf '%s\n' "$cmd" | grep -qE "Codex Computer Use\\.app|SkyComputerUseService"
+  [[ $cmd =~ $_CC_MONITOR_CODEX_UI_HELPER_PATTERN ]]
 }
 
 _cc_monitor_is_self_cmd() {
   local cmd=$1
-  printf '%s\n' "$cmd" | grep -qE "cc-monitor\\.sh( |$)|CCReaper\\.app/Contents/MacOS/CCReaper( |$)|/CCReaper( |$)"
+  [[ $cmd =~ $_CC_MONITOR_SELF_PATTERN ]]
 }
 
 _cc_monitor_is_normal_chrome_cmd() {
@@ -232,7 +261,7 @@ _cc_monitor_is_normal_chrome_cmd() {
   if _cc_monitor_is_agent_browser_cmd "$cmd" || _cc_monitor_is_puppeteer_chrome_cmd "$cmd"; then
     return 1
   fi
-  printf '%s\n' "$cmd" | grep -qE "Google Chrome\\.app|Google Chrome Helper|/Google Chrome( |$)|Chromium\\.app"
+  [[ $cmd =~ $_CC_MONITOR_NORMAL_CHROME_PATTERN ]]
 }
 
 _cc_monitor_is_immutable_cmd() {
@@ -293,9 +322,9 @@ _cc_monitor_family() {
     echo "codex"
   elif _cc_monitor_is_claude_agent_cmd "$cmd"; then
     echo "claude"
-  elif printf '%s\n' "$cmd" | grep -qE "Cursor Helper|Cursor\\.app|Visual Studio Code|Code Helper|/Code\\.app|/Cursor\\.app"; then
+  elif [[ $cmd =~ $_CC_MONITOR_EDITOR_PATTERN ]]; then
     echo "editor"
-  elif printf '%s\n' "$cmd" | grep -qE "(^|/)cmux( |$)|cmux\\.app"; then
+  elif [[ $cmd =~ $_CC_MONITOR_CMUX_PATTERN ]]; then
     echo "cmux"
   elif _cc_monitor_is_normal_chrome_cmd "$cmd"; then
     echo "chrome"
@@ -374,7 +403,7 @@ _cc_monitor_reason() {
     DO_NOT_KILL:*)
       echo "protected process matched cc-reaper safety boundaries" ;;
     *)
-      if printf '%s\n' "$cmd" | grep -qE "ChatGPT\\.app"; then
+      if [[ $cmd =~ $_CC_MONITOR_CHATGPT_PATTERN ]]; then
         echo "ChatGPT.app is protected user software"
       else
         echo "unknown process family; inspect manually before killing"
@@ -439,27 +468,27 @@ _cc_monitor_label() {
   local family=$1
   local cmd=$2
 
-  if printf '%s\n' "$cmd" | grep -q "Cursor Helper"; then
+  if [[ $cmd == *"Cursor Helper"* ]]; then
     echo "Cursor Helper"
-  elif printf '%s\n' "$cmd" | grep -q "Visual Studio Code"; then
+  elif [[ $cmd == *"Visual Studio Code"* ]]; then
     echo "VS Code"
-  elif printf '%s\n' "$cmd" | grep -q "WindowServer"; then
+  elif [[ $cmd == *"WindowServer"* ]]; then
     echo "WindowServer"
-  elif printf '%s\n' "$cmd" | grep -q "agent-browser-darwin-arm64"; then
+  elif [[ $cmd == *"agent-browser-darwin-arm64"* ]]; then
     echo "agent-browser"
-  elif printf '%s\n' "$cmd" | grep -q "puppeteer_dev_chrome_profile"; then
+  elif [[ $cmd == *"puppeteer_dev_chrome_profile"* ]]; then
     echo "Puppeteer Chrome"
-  elif printf '%s\n' "$cmd" | grep -q "Google Chrome for Testing"; then
+  elif [[ $cmd == *"Google Chrome for Testing"* ]]; then
     echo "Chrome for Testing"
-  elif printf '%s\n' "$cmd" | grep -q "react-scripts"; then
+  elif [[ $cmd == *"react-scripts"* ]]; then
     echo "react-scripts start"
-  elif printf '%s\n' "$cmd" | grep -q "chrome-devtools-mcp"; then
+  elif [[ $cmd == *"chrome-devtools-mcp"* ]]; then
     echo "chrome-devtools-mcp"
-  elif printf '%s\n' "$cmd" | grep -q "SkyComputerUseService\|Codex Computer Use\\.app"; then
+  elif [[ $cmd =~ $_CC_MONITOR_CODEX_UI_LABEL_PATTERN ]]; then
     echo "Codex Computer Use"
-  elif printf '%s\n' "$cmd" | grep -qE "CCReaper\\.app/Contents/MacOS/CCReaper|(^|/)CCReaper( |$)"; then
+  elif [[ $cmd =~ $_CC_MONITOR_SELF_LABEL_PATTERN ]]; then
     echo "cc-reaper"
-  elif printf '%s\n' "$cmd" | grep -qE "(^|/)cmux( |$)|cmux\\.app"; then
+  elif [[ $cmd =~ $_CC_MONITOR_CMUX_PATTERN ]]; then
     echo "cmux"
   elif [ "$family" = "chrome" ]; then
     echo "Google Chrome"


### PR DESCRIPTION
## The problem

The macOS companion app calls `cc-monitor --once --json` with a hard 30s
timeout (`CLIService.swift`'s `Timeout.scan`). On a machine running several
concurrent Claude Code sessions — each spinning up its own MCP server fleet
— the process table can run into the hundreds, and the app fails on every
scan with:

> cc-reaper monitor scan timed out after 30.0 seconds

Reported and reproduced on a machine with 6 concurrent Claude Code sessions
(background jobs), each with ~19 of its own MCP server processes — ~730
processes total system-wide.

## Root cause

`_cc_monitor_enrich_findings` classifies each matched process row by calling
a chain of ~15-20 predicate functions (`_cc_monitor_is_protected_cmd`,
`_cc_monitor_family`, `_cc_monitor_classification`, `_cc_monitor_label`,
`_cc_monitor_reason`, etc.), each implemented as
`printf '%s\n' "$cmd" | grep -qE "pattern"` — 2 forked processes per check.
With ~700 processes on the reporting machine, that's on the order of 14,000
forked subprocesses for a single scan.

Isolated timing on the affected machine confirmed the bottleneck precisely:

| Stage | Time |
|---|---|
| `_cc_monitor_collect_samples` (raw `ps` snapshot) | a couple seconds, 734 rows |
| `_cc_monitor_aggregate_samples` | a couple seconds, 734 rows |
| `_cc_monitor_enrich_findings` alone | **exceeded 3 minutes** (killed at the 180s harness timeout, still running) |

Full end-to-end: `bash shell/cc-monitor.sh --once --json` measured at
**89.6s wall / 40.7s system time** — system time that high, on a stage doing
no I/O beyond process listing, is the fork/exec overhead signature.

## The fix

Replace every `printf | grep -qE` predicate with bash's native
`[[ $cmd =~ $pattern ]]` regex match — same ERE syntax as `grep -E`, zero
forked processes.

Patterns are precomputed into module-level variables (`_CC_MONITOR_*_PATTERN`)
rather than written as bare literals after `=~`, for two reasons:
1. Avoids recomputing a static string on every call (the previous
   `_cc_monitor_protected_pattern()` function re-echoed its string on every
   invocation via a `$(...)` subshell).
2. **zsh compatibility.** `cc-monitor.sh` is sourced from `~/.zshrc` in
   normal use, and zsh's `[[ ]]` parser treats an unquoted `|` in an inline
   pattern as a pipe operator, failing with `parse error near '|'`. Routing
   the same pattern string through a variable first works identically in
   both shells. The existing test suite already exercises the zsh path
   (`tests/cc-monitor.sh`'s "zsh source mode" cases) — that's what caught
   this on the first pass of the fix, before it got anywhere near a PR.

I also hit (and fixed before this PR) a backslash-escaping mismatch: the
original `grep -E`-quoted patterns used `\\.` for an escaped literal dot,
which is correct inside a double-quoted string but means something
different (effectively broken) when the same characters appear unquoted
after `=~`. Verified the distinction empirically with disambiguating probe
strings before settling on single-backslash `\.` throughout — details in
the commit message.

## No behavior change intended

This is a fork-elimination performance fix, not a reclassification. Verified
by diffing test output, not just checking exit codes:

- All 15 files in `tests/*.sh` pass.
- Output of `tests/cc-monitor.sh`, `tests/protection-classes.sh`,
  `tests/agent-process-patterns.sh`, `tests/cc-monitor-optimize.sh`, and
  `tests/cc-monitor-runaway.sh` is **byte-identical** to the pre-patch
  baseline (both bash-mode and zsh-source-mode assertions).
- Both `bash -n` and `zsh -c "source shell/cc-monitor.sh"` are clean.

## Result

| | Before | After |
|---|---|---|
| `cc-monitor --once --json` on the affected machine | 89.6s | 13.8s |

6.5x faster, comfortably under the app's 30s timeout. Re-verified through
the actual deployed path (`~/.cc-reaper/cc-monitor.sh`, as both the app and
the `cc-monitor` shell function call it): ~11s, valid JSON, correct finding
count.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
