### PR TITLE
fix(worktree-janitor): name the binary that needs Full Disk Access

### DIFF
--- a/shell/worktree-janitor.sh
+++ b/shell/worktree-janitor.sh
@@ -112,6 +112,28 @@ _cc_wj_log_write() {
 # Called from `_cc_wj_run` rather than reported by `_cc_wj_discover_repos`: that one is
 # consumed through a process substitution, so a flag it sets is set in a child and the
 # caller never sees it.
+# The binary that must hold the grant, named rather than described.
+#
+# TCC grants are per-EXECUTABLE, and the executable under launchd is the interpreter,
+# not this script: the plist runs `/bin/bash /path/to/worktree-janitor.sh`. Measured
+# 2026-09-01, in a sibling project whose message had this same shape: an operator
+# granted Full Disk Access in direct response to it and the grant landed on their
+# terminal and their editor - both of which already had it, neither of which is what
+# launchd spawns - while `/bin/bash` stayed absent from the TCC database entirely. The
+# next run printed the identical denial.
+#
+# `install.sh` has said the precise thing since it was written, including the trade-off
+# and the alternative it prefers. This is the message the operator sees at the moment
+# it actually bites, and it was the weaker of the two.
+_cc_wj_grant_target() {
+  local prog
+  prog="$(ps -o comm= -p $$ 2>/dev/null | sed 's/^-//')"
+  case "$prog" in
+    /*) printf '%s' "$prog" ;;
+    *)  printf '%s' "${BASH:-/bin/bash}" ;;
+  esac
+}
+
 _cc_wj_unreadable_roots() {
   local root
   while IFS= read -r root; do
@@ -544,7 +566,13 @@ _cc_wj_run() {
   while IFS= read -r blind_root; do
     [ -n "$blind_root" ] || continue
     echo "worktree-janitor: root exists but cannot be read, scanned nothing: $blind_root" >&2
-    echo "worktree-janitor:   (under launchd, a path in ~/Documents, ~/Desktop or ~/Downloads needs Full Disk Access)" >&2
+    echo "worktree-janitor:   under launchd, ~/Documents, ~/Desktop and ~/Downloads need a" >&2
+    echo "worktree-janitor:   Full Disk Access grant on THIS binary: $(_cc_wj_grant_target)" >&2
+    echo "worktree-janitor:   System Settings > Privacy & Security > Full Disk Access > + > Cmd-Shift-G." >&2
+    echo "worktree-janitor:   Granting it to your terminal or editor does nothing: launchd spawns the" >&2
+    echo "worktree-janitor:   binary above. Note this hands EVERY bash script on the machine access to" >&2
+    echo "worktree-janitor:   all protected user data - keeping swept repositories outside those three" >&2
+    echo "worktree-janitor:   directories avoids the grant entirely, and is what install.sh prefers." >&2
     blind=1
   done < <(_cc_wj_unreadable_roots)
   fi

--- a/tests/worktree-janitor.sh
+++ b/tests/worktree-janitor.sh
@@ -346,6 +346,25 @@ expect_yes "a denied root says so rather than reporting an empty scan" \
   bash -c 'out=$(PATH="$3:$PATH" CC_WJ_ROOT="$2/denied" bash "$1" 2>&1); printf "%s\\n" "$out" | grep -q "could not be listed\\|cannot be read"' \
     _ "$ROOT_DIR/shell/worktree-janitor.sh" "$BLIND_ROOT" "$FIND_STUB_WJ"
 
+# The wording, not just the fact. A denial that says "needs Full Disk Access" without
+# naming the binary is what sent a real grant to a terminal that already had one, while
+# the binary launchd spawns stayed absent from the TCC database - measured 2026-09-01.
+expect_yes "a denied root names the binary to grant, not a description" \
+  bash -c 'out=$(PATH="$3:$PATH" CC_WJ_ROOT="$2/denied" bash "$1" 2>&1);
+           printf "%s\\n" "$out" | grep -q "THIS binary: /" &&
+           printf "%s\\n" "$out" | grep -q "Cmd-Shift-G" &&
+           ! printf "%s\\n" "$out" | grep -q "the program in the plist"' \
+    _ "$ROOT_DIR/shell/worktree-janitor.sh" "$BLIND_ROOT" "$FIND_STUB_WJ"
+
+# The trade-off and the alternative travel with it, or the message reads as an
+# instruction to grant rather than a decision to make. install.sh has said both since it
+# was written; this is the copy the operator sees when it actually bites.
+expect_yes "a denied root carries the trade-off and the alternative" \
+  bash -c 'out=$(PATH="$3:$PATH" CC_WJ_ROOT="$2/denied" bash "$1" 2>&1);
+           printf "%s\\n" "$out" | grep -q "EVERY bash script" &&
+           printf "%s\\n" "$out" | grep -q "outside those three"' \
+    _ "$ROOT_DIR/shell/worktree-janitor.sh" "$BLIND_ROOT" "$FIND_STUB_WJ"
+
 expect_yes "roots are plural" \
   bash -c 'CC_WJ_ROOT="/nope/a:/nope/b" bash "$1" 2>&1 | grep -q "/nope/a,/nope/b"' \
     _ "$ROOT_DIR/shell/worktree-janitor.sh"


### PR DESCRIPTION
Closes #22.

## The gap

`install.sh` has been precise about this since it was written — it names `/bin/bash`,
states that the grant hands **every** bash script on the machine access to all protected
user data, and recommends keeping swept repositories outside those directories instead.

The runtime message did not match:

```
(under launchd, a path in ~/Documents, ~/Desktop or ~/Downloads needs Full Disk Access)
```

No binary, no trade-off, no alternative — and it is the copy an operator sees at the
moment it bites, having read the installer's version days earlier.

## Vagueness is the defect, not the missing grant

Measured today in a sibling project whose message had the same shape. An operator granted
Full Disk Access in direct response to it. The system TCC database afterwards:

| client | FDA | granted |
|---|---|---|
| `com.anthropic.claude-code` | allowed | 2026-09-01 08:06:56 |
| `com.apple.Terminal` | allowed | earlier |
| **`/bin/bash`** | **absent entirely** | — |

The next run printed the identical denial. The grant went to interactive tools that
already had access; the binary launchd spawns got nothing.

## Now

```
worktree-janitor: root exists but cannot be read, scanned nothing: …
worktree-janitor:   under launchd, ~/Documents, ~/Desktop and ~/Downloads need a
worktree-janitor:   Full Disk Access grant on THIS binary: /bin/bash
worktree-janitor:   System Settings > Privacy & Security > Full Disk Access > + > Cmd-Shift-G.
worktree-janitor:   Granting it to your terminal or editor does nothing: launchd spawns the
worktree-janitor:   binary above. Note this hands EVERY bash script on the machine access to
worktree-janitor:   all protected user data - keeping swept repositories outside those three
worktree-janitor:   directories avoids the grant entirely, and is what install.sh prefers.
```

Path from `ps -o comm= -p $$` — the interpreter actually being denied, not one inferred.

## A correction I made to my own issue

I filed #22 claiming the five scheduled agents were blind, since they all run `/bin/bash`
over TCC-protected roots and all report exit 0. They do run `/bin/bash`, and the roots
are protected, **but the conclusion does not follow**: none of them reads those paths.
`weekly-clean` runs `disk-janitor.sh --clean`, and `worktree-janitor` is manual **by
design for exactly this reason** — which `install.sh:276-300` states plainly. Verified,
and the issue is corrected in place rather than left standing.

## Evidence

Two cases, both red against the old wording:

- a pasteable path is present and the old phrasing is gone
- the trade-off and the alternative travel with it — a message that only says "grant
  this" reads as an instruction rather than a decision

All 15 suites pass.

## Ruled out, so nobody retries them

- a private copy of the interpreter to grant instead → **rc=137, SIGKILL**; macOS library
  validation kills a relocated Apple-signed binary
- a non-Apple shell as the plist interpreter → none installed on this host

@codex review